### PR TITLE
fix: New API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Enhance your smart home setup by seamlessly connecting your Viessmann ViCare sys
 
 To use this plugin, you will need to create an API key by following these steps:
 
-1. **Create an Account**: Sign up for an account on the [Viessmann Developer Portal](https://app.developer.viessmann.com/).
+1. **Create an Account**: Sign up for an account on the [Viessmann Developer Portal](https://app.developer.viessmann-climatesolutions.com/).
 
 2. **Create a new client:**
 
@@ -44,7 +44,7 @@ To use this plugin, you will need to create an API key by following these steps:
       platform: 'ViCareThermostatPlatform',
       name: 'ViCareThermostat',
       clientId: 'YOUR CLIENT ID',
-      apiEndpoint: 'https://api.viessmann.com/iot/v1',
+      apiEndpoint: 'https://api.viessmann-climatesolutions.com/iot/v1',
       hostIp: 'YOUR HOST IP', // optional, default is the detected IP address
       devices: [
         {

--- a/src/RequestService.ts
+++ b/src/RequestService.ts
@@ -61,7 +61,7 @@ export class RequestService {
   }
 
   public async refreshAuth(): Promise<ViessmannAuthorization> {
-    const tokenUrl = 'https://iam.viessmann.com/idp/v3/token';
+    const tokenUrl = 'https://iam.viessmann-climatesolutions.com/idp/v3/token';
 
     const params = new URLSearchParams();
     params.set('client_id', this.clientId);

--- a/src/ViCareThermostatPlatform.ts
+++ b/src/ViCareThermostatPlatform.ts
@@ -184,7 +184,7 @@ export class ViCareThermostatPlatform {
     params.set('code_challenge_method', 'S256');
     params.set('code_challenge', this.codeChallenge);
 
-    const authUrl = `https://iam.viessmann.com/idp/v3/authorize?${params.toString()}`;
+    const authUrl = `https://iam.viessmann-climatesolutions.com/idp/v3/authorize?${params.toString()}`;
 
     this.log(`Click this link for authentication: ${authUrl}`);
     return this.getCodeViaServer();
@@ -218,7 +218,7 @@ export class ViCareThermostatPlatform {
   }
 
   private async exchangeCodeForToken(authCode: string): Promise<ViessmannAuthorization> {
-    const tokenUrl = 'https://iam.viessmann.com/idp/v3/token';
+    const tokenUrl = 'https://iam.viessmann-climatesolutions.com/idp/v3/token';
 
     const params = new URLSearchParams();
     params.set('client_id', this.clientId);


### PR DESCRIPTION
This uses the new Viessmann API URL `viessmann-climatesolutions.com`, announced in the [Viessmann Community](https://community.viessmann.de/t5/Announcements/Domain-Change-for-the-Viessmann-API/td-p/551560).