### PR TITLE
Add support for multiple gateways including feature check

### DIFF
--- a/src/ViCareThermostatPlatform.ts
+++ b/src/ViCareThermostatPlatform.ts
@@ -344,7 +344,7 @@ export class ViCareThermostatPlatform {
     deviceId: string
   ): Promise<string[]> {
     this.log.debug('Retrieving device features...');
-    const url = `${this.apiEndpoint}/equipment/installations/${installationId}/gateways/${gatewaySerial}/devices/${deviceId}/features`;
+    const url = `${this.apiEndpoint}/equipment/installations/${installationId}/gateways/${gatewaySerial}/devices/${deviceId}/features?skipDisabled`;
 
     try {
       const response = await this.requestService.authorizedRequest(url, 'get');
@@ -360,7 +360,7 @@ export class ViCareThermostatPlatform {
 
       const features = (body as ViessmannAPIResponse<ViessmannFeature<number>[]>).data;
       if (!features || features.length === 0) {
-        this.log.warn(`No features found for gateway ${gatewaySerial}, device ${deviceId}`);
+        this.log.warn(`No enabled features found for gateway ${gatewaySerial}, device ${deviceId}`);
         return [];
       }
 


### PR DESCRIPTION
Hi everybody,

This plugin initially supported only the first gateway.
In my setup, I have two gateways linked to the same installationId: “photovoltaic” and “heating”, each with different features. So my configured heating features failed each time because of the wrong gateway.

With this PR, I’ve added functionality to read all available `gatewaySerials` and verify whether the configured feature exists. An `accessory` will only be created if a matching feature is found.

I couldn’t find any testing guidelines, so this code is currently untested.

Please have a look.